### PR TITLE
feat: implemented basic error linting

### DIFF
--- a/src/app/editor/util/codemirror.setup.ts
+++ b/src/app/editor/util/codemirror.setup.ts
@@ -7,7 +7,7 @@ import { highlightActiveLineGutter, lineNumbers } from '@codemirror/gutter';
 import { defaultHighlightStyle } from '@codemirror/highlight';
 import { history, historyKeymap } from '@codemirror/history';
 import { indentOnInput } from '@codemirror/language';
-import { lintKeymap } from '@codemirror/lint';
+import { lintKeymap, linter } from '@codemirror/lint';
 import { bracketMatching } from '@codemirror/matchbrackets';
 import { highlightSelectionMatches, searchKeymap } from '@codemirror/search';
 import { EditorState } from '@codemirror/state';
@@ -18,6 +18,7 @@ import {
   keymap,
 } from '@codemirror/view';
 import { karol } from '@robotcoral/lang-karol';
+import { lintKarol } from './linter';
 
 export * from '@codemirror/history';
 export { EditorState } from '@codemirror/state';
@@ -50,4 +51,5 @@ export const customSetup = [
     indentWithTab,
   ]),
   karol(),
+  linter(lintKarol),
 ];

--- a/src/app/editor/util/linter.ts
+++ b/src/app/editor/util/linter.ts
@@ -1,0 +1,19 @@
+import { Diagnostic } from '@codemirror/lint';
+import { EditorView } from '@codemirror/view';
+import { compile } from '@robotcoral/lang-karol';
+
+export function lintKarol(view: EditorView): Diagnostic[] {
+    try {
+        compile(view.state.doc.toString());
+        return [];
+    } catch(err: any) {
+        return [
+            {
+                from: err.pos.from,
+                to: err.pos.to, 
+                severity: "error",
+                message: err.msg,
+            }
+        ];
+    }
+}

--- a/src/app/editor/util/linter.ts
+++ b/src/app/editor/util/linter.ts
@@ -3,17 +3,17 @@ import { EditorView } from '@codemirror/view';
 import { compile } from '@robotcoral/lang-karol';
 
 export function lintKarol(view: EditorView): Diagnostic[] {
-    try {
-        compile(view.state.doc.toString());
-        return [];
-    } catch(err: any) {
-        return [
-            {
-                from: err.pos.from,
-                to: err.pos.to, 
-                severity: "error",
-                message: err.msg,
-            }
-        ];
-    }
+  try {
+    compile(view.state.doc.toString());
+    return [];
+  } catch (err: any) {
+    return [
+      {
+        from: err.pos.from,
+        to: err.pos.to,
+        severity: 'error',
+        message: err.msg,
+      },
+    ];
+  }
 }


### PR DESCRIPTION
Implements basic error linting. Only lints the first occuring error in the sourcecode. For more advanced linting, lang-karol's error handling must be changed.